### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Build and Deploy to Render.yml
+++ b/.github/workflows/Build and Deploy to Render.yml
@@ -5,6 +5,8 @@ on:
         description: 'Deployment environment'
         required: true
         default: 'production'
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/HarshalBeniwal/Fairshare/security/code-scanning/3](https://github.com/HarshalBeniwal/Fairshare/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not use the `GITHUB_TOKEN` directly, we can set the permissions to `contents: read`, which is the minimal permission required for most workflows.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `deploy` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
